### PR TITLE
refactor FragmentTWMaskViewModelRxImpl

### DIFF
--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/extension/RxExt.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/extension/RxExt.kt
@@ -1,0 +1,8 @@
+package com.ken.android.app.novel.covid19.report.extension
+
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+
+
+fun Disposable.addTo(compositeDisposable: CompositeDisposable) =
+    this.also { compositeDisposable.add(it) }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/BaseRxViewModel.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/BaseRxViewModel.kt
@@ -7,7 +7,7 @@ import io.reactivex.disposables.CompositeDisposable
 
 open class BaseRxViewModel : ViewModel() {
 
-    protected var compositeDisposable = CompositeDisposable()
+    protected val compositeDisposable = CompositeDisposable()
     protected var isLoading = MutableLiveData<Boolean>(false)
 
     @VisibleForTesting
@@ -15,9 +15,8 @@ open class BaseRxViewModel : ViewModel() {
         this.isLoading = isLoading
     }
 
-
-    fun destroy(){
-        compositeDisposable.clear()
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.dispose()
     }
-
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/COVID19InfoViewModel.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/COVID19InfoViewModel.kt
@@ -18,5 +18,4 @@ interface COVID19InfoViewModel {
     fun loadCountries()
     fun loadCountries(sort : String)
     fun search(country: String)
-    fun destroy()
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/COVID19InfoViewModelImpl.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/COVID19InfoViewModelImpl.kt
@@ -76,11 +76,6 @@ class COVID19InfoViewModelImpl : ViewModel(), COVID19InfoViewModel {
         covid19Repository.search(country)
     }
 
-    override fun destroy() {
-
-
-    }
-
     override fun getGlobalCaseLiveData(): LiveData<GlobalTotalCase> {
         return globalTotalCaseLiveData
     }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/FragmentCOVID19Info.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/info/FragmentCOVID19Info.kt
@@ -5,6 +5,7 @@ import android.view.*
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,10 +21,7 @@ class FragmentCOVID19Info : Fragment() {
         const val TAG = "FragmentCOVID19Info"
     }
 
-    private val infoViewModel : COVID19InfoViewModel by lazy {
-        ViewModelProvider.AndroidViewModelFactory.getInstance(requireActivity().application).create(
-            COVID19InfoViewModelRxImpl::class.java)
-    }
+    private val infoViewModel: COVID19InfoViewModel by viewModels<COVID19InfoViewModelRxImpl>()
 
     private lateinit var binding : FragmentCountryBinding
     private var adapter = COVID19InfoListAdapter()
@@ -86,31 +84,31 @@ class FragmentCOVID19Info : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        infoViewModel.getGlobalCaseLiveData().observe(requireActivity(), Observer {
+        infoViewModel.getGlobalCaseLiveData().observe(viewLifecycleOwner, Observer {
             adapter.setGlobalCase(it)
             infoViewModel.loadCountries()
         })
 
-        infoViewModel.getGlobalCaseErrorLiveData().observe(requireActivity(), Observer {
+        infoViewModel.getGlobalCaseErrorLiveData().observe(viewLifecycleOwner, Observer {
             infoViewModel.loadCountries()
         })
 
-        infoViewModel.getCountriesLiveData().observe(requireActivity(), Observer {
+        infoViewModel.getCountriesLiveData().observe(viewLifecycleOwner, Observer {
             binding.refresh.isRefreshing = false
             adapter.setCountryList(it)
             adapter.notifyDataSetChanged()
         })
 
-        infoViewModel.getCOVID19ChartLiveData().observe(requireActivity(), Observer {
+        infoViewModel.getCOVID19ChartLiveData().observe(viewLifecycleOwner, Observer {
             adapter.setCOVID19ChartData(it)
             adapter.notifyDataSetChanged()
         })
-        infoViewModel.getCountriesErrorLiveData().observe(requireActivity(), Observer {
+        infoViewModel.getCountriesErrorLiveData().observe(viewLifecycleOwner, Observer {
             Toast.makeText(requireActivity(), "error $it", Toast.LENGTH_LONG).show()
             adapter.notifyDataSetChanged()
         })
 
-        infoViewModel.searchErrorLiveData().observe(requireActivity(), Observer {
+        infoViewModel.searchErrorLiveData().observe(viewLifecycleOwner, Observer {
             val searchNotFoundKeyWord = resources.getString(R.string.search_not_found)
             Toast.makeText(requireActivity(),String.format(searchNotFoundKeyWord, it) , Toast.LENGTH_SHORT).show()
         })
@@ -121,11 +119,4 @@ class FragmentCOVID19Info : Fragment() {
         binding.countryRecyclerView.adapter = adapter
         infoViewModel.loadGlobalTotalCase()
     }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        infoViewModel.destroy()
-    }
-
-
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskMap.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskMap.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -27,6 +28,8 @@ import com.ken.android.app.novel.covid19.report.R
 import com.ken.android.app.novel.covid19.report.databinding.FragmentTwMaskMapBinding
 import com.ken.android.app.novel.covid19.report.repository.bean.Feature
 import com.ken.android.app.novel.covid19.report.repository.bean.KiangGeoJson
+import com.ken.android.app.novel.covid19.report.repository.remote.OKHttpBaseInterceptor
+import com.ken.android.app.novel.covid19.report.repository.remote.rx.TaiwanMaskRxApiRepository
 import com.ken.android.app.novel.covid19.report.ui.map.cluster.TWMaskClusterItem
 import com.ken.android.app.novel.covid19.report.ui.map.cluster.TWMaskClusterMarkerManager
 import com.ken.android.app.novel.covid19.report.ui.map.cluster.TWMaskClusterRender
@@ -41,7 +44,11 @@ class FragmentTWMaskMap : Fragment(), OnMapReadyCallback {
     }
     private lateinit var mMap: GoogleMap
 
-    private lateinit var viewModel : FragmentTWMaskViewModel
+    private val viewModel: FragmentTWMaskViewModel by viewModels<FragmentTWMaskViewModelRxImpl> {
+        FragmentTWMaskViewModelRxImpl.Factory(
+            TaiwanMaskRxApiRepository(OKHttpBaseInterceptor())
+        )
+    }
     private lateinit var binding : FragmentTwMaskMapBinding
     private lateinit var mMapFragment : SupportMapFragment
     private var currentDisplayInfoWindowMark : Marker? = null
@@ -56,7 +63,6 @@ class FragmentTWMaskMap : Fragment(), OnMapReadyCallback {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate<FragmentTwMaskMapBinding>(inflater, R.layout.fragment_tw_mask_map, container, false)
         mMapFragment = childFragmentManager.findFragmentById(R.id.fragment_map) as SupportMapFragment
-        viewModel = FragmentTWMaskViewModelRxImpl()
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
         return binding.root

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskViewModel.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskViewModel.kt
@@ -9,5 +9,4 @@ interface FragmentTWMaskViewModel {
     fun isLoading() : LiveData<Boolean>
     fun getGeoJsonLiveData() : LiveData<KiangGeoJson>
     fun loadMaskMapData()
-    fun destroy()
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskViewModelRxImpl.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/map/FragmentTWMaskViewModelRxImpl.kt
@@ -3,18 +3,22 @@ package com.ken.android.app.novel.covid19.report.ui.map
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.ken.android.app.novel.covid19.report.extension.addTo
 import com.ken.android.app.novel.covid19.report.plusAssign
 import com.ken.android.app.novel.covid19.report.repository.bean.KiangGeoJson
 import com.ken.android.app.novel.covid19.report.repository.remote.OKHttpBaseInterceptor
 import com.ken.android.app.novel.covid19.report.repository.remote.rx.TaiwanMaskRxApiRepository
 import com.ken.android.app.novel.covid19.report.ui.BaseRxViewModel
 
-class FragmentTWMaskViewModelRxImpl : BaseRxViewModel(), FragmentTWMaskViewModel {
+class FragmentTWMaskViewModelRxImpl(
+    private val mapRepository: TaiwanMaskRxApiRepository
+) : BaseRxViewModel(), FragmentTWMaskViewModel {
     companion object{
         private const val TAG = "TWMaskViewModel"
     }
-    private var mapRepository = TaiwanMaskRxApiRepository(OKHttpBaseInterceptor())
-    private var geoJsonLiveData = MutableLiveData<KiangGeoJson>()
+    private val geoJsonLiveData = MutableLiveData<KiangGeoJson>()
 
 
 
@@ -30,7 +34,7 @@ class FragmentTWMaskViewModelRxImpl : BaseRxViewModel(), FragmentTWMaskViewModel
     override fun loadMaskMapData() {
         isLoading.value = true
 
-        compositeDisposable += mapRepository.getPoint()
+        mapRepository.getPoint()
             .doFinally{
                 isLoading.value = false
             }
@@ -42,6 +46,17 @@ class FragmentTWMaskViewModelRxImpl : BaseRxViewModel(), FragmentTWMaskViewModel
 
 
         })
+            .addTo(compositeDisposable)
     }
 
+    class Factory(
+        private val mapRepository: TaiwanMaskRxApiRepository
+    ) : ViewModelProvider.NewInstanceFactory() {
+
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return FragmentTWMaskViewModelRxImpl(
+                mapRepository
+            ) as T
+        }
+    }
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/FragmentNews.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/FragmentNews.kt
@@ -83,9 +83,4 @@ class FragmentNews : Fragment() {
         super.onResume()
 
     }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        viewModel.destroy()
-    }
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/NewsViewModel.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/NewsViewModel.kt
@@ -10,6 +10,4 @@ interface NewsViewModel {
     fun getErrorLiveData() : LiveData<String>
     fun isLoading() : LiveData<Boolean>
     fun loadNews(searchKey : String)
-
-    fun destroy()
 }

--- a/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/NewsViewModelImpl.kt
+++ b/app/src/main/java/com/ken/android/app/novel/covid19/report/ui/news/NewsViewModelImpl.kt
@@ -28,11 +28,6 @@ class NewsViewModelImpl : ViewModel(), NewsViewModel {
         newsApiRepository.loadNews(searchKey)
     }
 
-    override fun destroy() {
-
-    }
-
-
     override fun getNewsLiveData(): LiveData<ArrayList<NewsArticle>> {
         return newsLiveDataLazy
     }


### PR DESCRIPTION
1. 將測試會需要 mock 掉的東西改從外部傳入(FragmentTWMaskViewModelRxImpl 的 mapRepository)
2. 善用 by viewModels 和 by activityViewModels，Android MVVM 架構會讓 ViewModel 具有生命週期的概念，所以可以不用自己處理 destroy，override onCleared 即可
3. 盡量讓 val 取代 var，越少東西可改變出錯的機率越低
4. LiveData 具有生命週期概念，只有在前景(onResume)的狀態下才會通知觀察者資料更新，觀察 LiveData 時使用的 observe function，第一個參數是送入 lifecycleOwner，所以請考慮要與 LiveData 搭配的  lifecycleOwner 是誰。FragmentCOVID19Info 中原本你傳入的是 activity，會導致 fragment 如果被 detach 而 activity 仍在前景時，fragment 仍會收到資料，可能會產生 crash 與 memory leak
5. fragment view 的初始化請善用 onViewCreate()，onCreateView 是讓你產生 view 的 function，而 onActivityCreate() 這個 function 在未來的版本已經被 deprecatred 了
6. 請不要接受這個 PR